### PR TITLE
Update teamwork data guide

### DIFF
--- a/team_work/teamwork_data_guide.ipynb
+++ b/team_work/teamwork_data_guide.ipynb
@@ -23,7 +23,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "## STAC data access\n",
+    "## STAC data access: Sentinel-1 from EODC\n",
     "\n",
     "Here, a quick recap of [Unit 1]() of the course on how to access data available through STAC. For more details re-visit the corresponding notebook!"
    ]
@@ -36,6 +36,11 @@
    "outputs": [],
    "source": [
     "import gc\n",
+    "import os\n",
+    "\n",
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt\n",
     "\n",
     "import pystac_client\n",
     "from odc import stac as odc_stac"
@@ -70,7 +75,8 @@
    "id": "5",
    "metadata": {},
    "source": [
-    "We will now load Sentinel-1 data for the area of Innsbruck from STAC."
+    "We will now load **Sentinel-1** data for the area surrounding **Innsbruck** using **STAC**.  \n",
+    "First, we define a **spatial bounding box** covering the Innsbruck region, and apply a **temporal filter** spanning the entire month of **March 2022**."
    ]
   },
   {
@@ -82,6 +88,14 @@
    "source": [
     "time_range = \"2022-03-01/2022-03-31\"\n",
     "innsbruck_bbox = (11.070099, 47.148400, 11.729279, 47.380219)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4dedcef",
+   "metadata": {},
+   "source": [
+    "Next, we query the **EODC STAC catalog** for items from the **SENTINEL1_SIG0_20M** collection that match these spatiotemporal constraints."
    ]
   },
   {
@@ -99,6 +113,17 @@
     ")\n",
     "s1_items = search.item_collection()\n",
     "len(s1_items)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbeb51ba",
+   "metadata": {},
+   "source": [
+    "We use the **`odc-stac`** package to load STAC-compliant items directly into an **xarray** dataset.  \n",
+    "For more details, refer to the [official documentation](https://odc-stac.readthedocs.io/en/latest/).\n",
+    "\n",
+    "Specifically, we'll load the **Sentinel-1 SIG0** data we retrieved earlier as a three-dimensional datacube with dimensions **(time, lat, lon)**, and extract the **VV** polarization band."
    ]
   },
   {
@@ -120,12 +145,41 @@
     "    chunks=chunks,\n",
     "    resampling=\"bilinear\",\n",
     ")\n",
+    "sig0_dc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9769746f",
+   "metadata": {},
+   "source": [
+    "To reduce storage requirements, this data is stored as **int16 arrays** together with a **scaling factor** that converts the integer values to floating-point reflectance values on demand.  \n",
+    "To visualize or process the data correctly, we need to read this scaling factor from the dataset's metadata and apply it.\n",
+    "\n",
+    "Finally, we'll also inspect the metadata to find the **nodata flag** (the value used to mark missing data) and filter out those empty observations before proceeding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "020ff60a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "\n",
     "scale = s1_items[0].assets[\"VV\"].extra_fields.get(\"raster:bands\")[0][\"scale\"]\n",
     "nodata = s1_items[0].assets[\"VV\"].extra_fields.get(\"raster:bands\")[0][\"nodata\"]\n",
     "sig0_dc = sig0_dc.where(sig0_dc != nodata) / scale\n",
     "sig0_dc = sig0_dc.dropna(dim=\"time\")\n",
     "sig0_dc.VV"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c563ddc9",
+   "metadata": {},
+   "source": [
+    "We then compute the mean over the timeslices that remained, and plot it with xarray's plotting function, which provides us with some quality-of-life features like automatically adding axis labels and a legend for the colormap."
    ]
   },
   {
@@ -137,6 +191,14 @@
    "source": [
     "sig0_mean = sig0_dc.mean(dim=\"time\", skipna=True)\n",
     "sig0_mean.VV.plot(robust=True, cmap=\"Greys_r\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7dd346f7",
+   "metadata": {},
+   "source": [
+    "Finally, we deallocate the memory for the data we just loaded and manually run python's garbage collector."
    ]
   },
   {
@@ -152,27 +214,21 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09a0cad4",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ded65247",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import numpy as np\n",
-    "from matplotlib import pyplot as plt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "3b728cde",
    "metadata": {},
-   "source": []
+   "source": [
+    "## STAC data access: Sentinel-2 from CDSE\n",
+    "\n",
+    "There are several services that provide **Earth Observation (EO)** data through **STAC APIs**.  \n",
+    "One of them is the **[Copernicus Data Space Ecosystem (CDSE)](https://dataspace.copernicus.eu/)**. In this section, we will access and manipulate Sentinel-2 optical data provided by CDSE.\n",
+    "\n",
+    "The CDSE STAC catalog can be accessed via the  \n",
+    "[CDSE STAC Browser](https://browser.stac.dataspace.copernicus.eu/?language=en). Comprehensive documentation is available on the [CDSE website](https://dataspace.copernicus.eu/). Unlike the **EODC** STAC API, the **CDSE** API requires users to register and generate **S3 API keys**.  \n",
+    "This process is straightforward and described in the [official guide](https://documentation.dataspace.copernicus.eu/APIs/S3.html).\n",
+    "\n",
+    "Once you have created your keys, copy both the **Access Key** and **Secret Access Key** into a text file named `keys.txt`, placed in the same directory as this notebook.  \n",
+    "Running the cell below will then configure the necessary environment variables, enabling access to the **CDSE STAC API**.\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -181,20 +237,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.environ[\"GDAL_HTTP_TCP_KEEPALIVE\"] = \"YES\"\n",
+    "with open(\"keys.txt\", \"r\") as f:\n",
+    "    access_key, secret_access_key = [line.strip() for line in f.readlines()]\n",
+    "\n",
+    "os.environ[\"AWS_ACCESS_KEY_ID\"] = access_key\n",
+    "os.environ[\"AWS_SECRET_ACCESS_KEY\"] = secret_access_key\n",
     "os.environ[\"AWS_S3_ENDPOINT\"] = \"eodata.dataspace.copernicus.eu\"\n",
-    "os.environ[\"AWS_ACCESS_KEY_ID\"] = \"\"  # Add your key\n",
-    "os.environ[\"AWS_SECRET_ACCESS_KEY\"] = \"\"  # Add your key\n",
-    "os.environ[\"AWS_HTTPS\"] = \"YES\"\n",
-    "os.environ[\"AWS_VIRTUAL_HOSTING\"] = \"FALSE\"\n",
-    "os.environ[\"GDAL_HTTP_UNSAFESSL\"] = \"YES\""
+    "os.environ[\"AWS_VIRTUAL_HOSTING\"] = \"FALSE\"\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "b58571de",
    "metadata": {},
-   "source": []
+   "source": [
+    "Now we simply follow a similar procedure to the one we employed for the EODC STAC, listing all the collections available in the CDSE catalog."
+   ]
   },
   {
    "cell_type": "code",
@@ -217,7 +275,9 @@
    "cell_type": "markdown",
    "id": "070eadfd",
    "metadata": {},
-   "source": []
+   "source": [
+    "Again, just like in the Sentinel-1 Section, we define a spatiotemporal filter around the Innsbruck region and covering March 2022. We then query the CDSE catalog for Sentinel-2 Level 2A optical data that fulfills our requirements."
+   ]
   },
   {
    "cell_type": "code",
@@ -227,22 +287,8 @@
    "outputs": [],
    "source": [
     "time_range = \"2022-03-01/2022-03-31\"\n",
-    "innsbruck_bbox = (11.070099, 47.148400, 11.729279, 47.380219)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7c2cd143",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "92c78315",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "innsbruck_bbox = (11.070099, 47.148400, 11.729279, 47.380219)\n",
+    "\n",
     "s2_collection_id = \"sentinel-2-l2a\"\n",
     "search = cdse_catalog.search(\n",
     "    collections=s2_collection_id,\n",
@@ -257,7 +303,9 @@
    "cell_type": "markdown",
    "id": "ed9ab2be",
    "metadata": {},
-   "source": []
+   "source": [
+    "This time, we query an xarray dataset with the bands [\"B02_10m\",\"B03_10m\",\"B04_10m\"], which correspond to blue, green and red, respectively. "
+   ]
   },
   {
    "cell_type": "code",
@@ -281,15 +329,23 @@
     "    resampling=\"bilinear\",\n",
     ")\n",
     "\n",
-    "s2_dc\n",
-    "\n"
+    "s2_dc"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "319d2e55",
    "metadata": {},
-   "source": []
+   "source": [
+    "Next, we'll visualize the first observation from our search results as a **true-color RGB image**.\n",
+    "\n",
+    "To do this, we first create a new **xarray `DataArray`** that stacks the three visible bands (red, green, and blue) along a new `band` dimension using `xr.concat`.  \n",
+    "This gives us an array with dimensions **(band, lat, lon)**, where each band corresponds to one color channel.\n",
+    "\n",
+    "We then scale the data values to the **[0, 1] range** by dividing by the appropriate factor, ensuring the image displays correctly when plotted.\n",
+    "\n",
+    "Finally, we use **`xarray.plot.imshow()`** with the `rgb=\"band\"` argument, which tells xarray to interpret the `band` dimension as RGB channels and render a color image automatically.\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -298,11 +354,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s2_first_date = s2_dc.isel(time=0)\n",
+    "first_date = str(np.datetime_as_string(s2_dc.time[0], unit='D'))\n",
+    "s2_data_first_date = s2_dc.isel(time=0)\n",
     "\n",
-    "rgb = np.dstack([s2_first_date['B02_10m'],s2_first_date['B03_10m'],s2_first_date['B04_10m']])\n",
-    "scaled_rgb = np.clip(rgb/10000,0,1)\n",
-    "plt.imshow(scaled_rgb)\n"
+    "rgb_da = xr.concat(\n",
+    "    [s2_data_first_date[\"B04_10m\"],  # red\n",
+    "     s2_data_first_date[\"B03_10m\"],  # green\n",
+    "     s2_data_first_date[\"B02_10m\"]], # blue\n",
+    "    dim=\"band\"\n",
+    ").assign_coords(band=[\"R\", \"G\", \"B\"])\n",
+    "\n",
+    "rgb_da = rgb_da.astype(\"float32\") / 10000.0\n",
+    "rgb_da = rgb_da.clip(0.0, 1.0)\n",
+    "\n",
+    "rgb_da.plot.imshow(rgb=\"band\")\n",
+    "plt.title(f\"Sentinel-2 L2A RGB, {first_date}\")\n",
+    "plt.show()"
    ]
   }
  ],

--- a/team_work/teamwork_data_guide.ipynb
+++ b/team_work/teamwork_data_guide.ipynb
@@ -152,364 +152,165 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "09a0cad4",
    "metadata": {},
-   "source": [
-    "## Data on JupyterHub\n",
-    "\n",
-    "Besides the data you saw in the hand-on exercises, the Austrian Datacube (=ACube) is available through the JupyterHub. You can find the data under: `/shared/datasets/fe/data`\n",
-    "\n",
-    "Currently, there are 3 types of datasets available:\n",
-    "\n",
-    "- Sentinel-1 data\n",
-    "- Sentinel-2 data\n",
-    "- Auxiliary data\n",
-    "\n",
-    "### Data structure\n",
-    "\n",
-    "The data is projected and tiled based on the Equi7Grid. Therefore, all datasets follow the same folder structure:\n",
-    "\n",
-    "PRODUCT / SUBGRID / TILE / LAYER"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "ded65247",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
-    "\n",
-    "import pandas as pd\n",
-    "import xarray as xr"
+    "import os\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "3b728cde",
    "metadata": {},
-   "source": [
-    "Consequently, we can define our input paths like this:"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "b351b4b1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "source_path = Path(r\"~/shared/datasets/fe/data\").expanduser()\n",
-    "# additional data for team part\n",
-    "\n",
-    "res = 10  # 10m or 500m\n",
-    "sentinel1_parameter_path = (\n",
-    "    source_path / \"sentinel1\" / \"parameters\" / (f\"EU{str(res).zfill(3)}M\")\n",
-    ")\n",
-    "sentinel1_preprocessed_path = (\n",
-    "    source_path / \"sentinel1\" / \"preprocessed\" / (f\"EU{str(res).zfill(3)}M\")\n",
-    ")\n",
-    "sentinel2_path = source_path / \"sentinel2\" / \"L2A\" / \"EU010M\"\n",
-    "\n",
-    "sentinel1_parameter_path"
+    "os.environ[\"GDAL_HTTP_TCP_KEEPALIVE\"] = \"YES\"\n",
+    "os.environ[\"AWS_S3_ENDPOINT\"] = \"eodata.dataspace.copernicus.eu\"\n",
+    "os.environ[\"AWS_ACCESS_KEY_ID\"] = \"\"  # Add your key\n",
+    "os.environ[\"AWS_SECRET_ACCESS_KEY\"] = \"\"  # Add your key\n",
+    "os.environ[\"AWS_HTTPS\"] = \"YES\"\n",
+    "os.environ[\"AWS_VIRTUAL_HOSTING\"] = \"FALSE\"\n",
+    "os.environ[\"GDAL_HTTP_UNSAFESSL\"] = \"YES\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "b58571de",
    "metadata": {},
-   "source": [
-    "### Load data\n",
-    "Once the input paths are defined, one can collect the required data. In the following examples, you can see how single or multiple files can be loaded as xarray object.\n",
-    "\n",
-    "#### Sentinel-1 (single file)\n",
-    "How to load a single Sentinel-1 observation file:\n",
-    "- Collect file from file system\n",
-    "- Load it as `xarray.DataSet`\n",
-    "- Prepare the data for further usage (decoding and clean-up)\n",
-    "- Work with the data"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "93c068cb",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def acube_s1_preprocess(x: xr.Dataset) -> xr.Dataset:\n",
-    "    \"\"\"Decode and clean up Sentinel-1 ACube data.\n",
+    "# collections provided by the CDSE STAC Catalog\n",
+    "cdse_catalog = pystac_client.Client.open(\"https://stac.dataspace.copernicus.eu/v1\")\n",
     "\n",
-    "    Parameters\n",
-    "    ----------\n",
-    "    x : xarray.Dataset\n",
-    "        Input dataset.\n",
+    "cdse_collections = cdse_catalog.get_collections()\n",
+    "max_length = max(len(collection.id) for collection in cdse_collections)\n",
     "\n",
-    "    Returns\n",
-    "    -------\n",
-    "    xarray.Dataset\n",
-    "\n",
-    "    \"\"\"\n",
-    "    path = Path(x.encoding[\"source\"])\n",
-    "    filename = path.name\n",
-    "\n",
-    "    date_str = filename.split(\"_\")[0][1:]\n",
-    "    time_str = filename.split(\"_\")[1][:6]\n",
-    "    datetime_str = date_str + time_str\n",
-    "    date = pd.to_datetime(datetime_str, format=\"%Y%m%d%H%M%S\")\n",
-    "    x = x.expand_dims(dim={\"time\": [date]})\n",
-    "\n",
-    "    x = (\n",
-    "        x.rename({\"band_data\": \"s1_\" + path.parent.stem})\n",
-    "        .squeeze(\"band\")\n",
-    "        .drop_vars(\"band\")\n",
-    "    )\n",
-    "\n",
-    "    return x * 0.01"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "single_path = (\n",
-    "    sentinel1_preprocessed_path\n",
-    "    / \"E051N015T1\"\n",
-    "    / \"sig0\"\n",
-    "    / \"D20210122_165830--_SIG0-----_S1BIWGRDH1VVA_044_A0105_EU010M_E051N015T1.tif\"\n",
-    ")\n",
-    "\n",
-    "s1 = xr.open_dataset(\n",
-    "    single_path,\n",
-    "    engine=\"rasterio\",\n",
-    ")\n",
-    "s1 = acube_s1_preprocess(s1)\n",
-    "s1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "18",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# visualize data\n",
-    "s1.hvplot.image(robust=True, data_aspect=1, cmap=\"Greys_r\", rasterize=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "19",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "del s1\n",
-    "gc.collect()"
+    "for collection in cdse_catalog.get_collections():\n",
+    "    print(f\"{collection.id.ljust(max_length)}: {collection.title}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "070eadfd",
    "metadata": {},
-   "source": [
-    "#### Sentinel-1 (multiple files)\n",
-    "Similar to the hands-on exercises, one can load multiple Sentinel-1 files at once, but be aware of the limited availability of memory in the JupyterHub. It is suggested to use the provided statistical parameters (introduced below) instead of loading multi-temporal data."
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "c856f394",
    "metadata": {},
    "outputs": [],
    "source": [
-    "tile_path = single_path = sentinel1_preprocessed_path / \"E051N015T1\" / \"sig0\"\n",
-    "sig0_day_paths = list(tile_path.glob(\"D20210122*S1*IWGRDH1VV*.tif\"))\n",
-    "len(sig0_day_paths)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "s1_day = xr.open_mfdataset(\n",
-    "    sig0_day_paths,\n",
-    "    engine=\"rasterio\",\n",
-    "    combine=\"nested\",\n",
-    "    chunks=-1,\n",
-    "    preprocess=acube_s1_preprocess,\n",
-    ")\n",
-    "\n",
-    "s1_day"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "23",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "s1_day = s1_day.mean(dim=\"time\", skipna=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "24",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "s1_day.hvplot.image(robust=True, data_aspect=1, cmap=\"Greys_r\", rasterize=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "25",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "del s1_day\n",
-    "gc.collect()"
+    "time_range = \"2022-03-01/2022-03-31\"\n",
+    "innsbruck_bbox = (11.070099, 47.148400, 11.729279, 47.380219)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "7c2cd143",
    "metadata": {},
-   "source": [
-    "### Sentinel-1 (parameters)\n",
-    "Parameters are statistics based on the Sentinel-1 backscatter and they are provided under: `~/shared/data/sentinel1/parameters`\n",
-    "\n",
-    "The most relevant statistical parameters are:\n",
-    "\n",
-    "- tmaxsig0: Maximum SIG0 backscatter per relative orbit\n",
-    "- tmaxsig38: Maximum SIG0 backscatter normalized to an incidence angle of 38 degree\n",
-    "- tmensig0: Average SIG0 backscatter per relative orbit\n",
-    "- tmensig38: Average SIG0 backscatter normalized to an incidence angle of 38 degree\n",
-    "- tminsig0: Minimum SIG0 backscatter per relative orbit\n",
-    "- tminsig38: Minimum SIG0 backscatter normalized to an incidence angle of 38 degree"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "92c78315",
    "metadata": {},
    "outputs": [],
    "source": [
-    "par_path = (\n",
-    "    sentinel1_parameter_path\n",
-    "    / \"E051N015T1\"\n",
-    "    / \"tmensig0\"\n",
-    "    / \"M20160101_20171231_TMENSIG0-_S1-IWGRDH1VV-_124_B0104_EU010M_E051N015T1.tif\"\n",
+    "s2_collection_id = \"sentinel-2-l2a\"\n",
+    "search = cdse_catalog.search(\n",
+    "    collections=s2_collection_id,\n",
+    "    bbox=innsbruck_bbox,\n",
+    "    datetime=time_range,\n",
     ")\n",
-    "\n",
-    "par = xr.open_dataset(\n",
-    "    par_path,\n",
-    "    engine=\"rasterio\",\n",
-    ")\n",
-    "par = acube_s1_preprocess(par)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "28",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "par.hvplot.image(robust=True, data_aspect=1, cmap=\"Greys_r\", rasterize=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "29",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "del par\n",
-    "gc.collect()"
+    "s2_items = search.item_collection()\n",
+    "len(s2_items)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "ed9ab2be",
    "metadata": {},
-   "source": [
-    "### Sentinel-2\n",
-    "Sentinel-2 data is available under `~/shared/datasets/fe/data/sentinel2`\n",
-    "\n",
-    "In this example, we will load the true-color image (TCI), but the dataset contains all the available bands from Sentinel-2."
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "1cee1ba3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "s2_path = (\n",
-    "    sentinel2_path\n",
-    "    / \"E051N015T1\"\n",
-    "    / \"tci\"\n",
-    "    / \"TCI-------_SEN2COR_S2B_L2A------_20210125_20210125_EU010M_E051N015T1.tif\"\n",
+    "chunks = {\"time\": 1, \"latitude\": 500, \"longitude\": 500}\n",
+    "\n",
+    "\n",
+    "bands=[\"B02_10m\",\"B03_10m\",\"B04_10m\"]\n",
+    "\n",
+    "s2_dc = odc_stac.load(\n",
+    "    s2_items,\n",
+    "    bands=bands,\n",
+    "    crs=\"EPSG:27704\",\n",
+    "    resolution=20,\n",
+    "    bbox=innsbruck_bbox,\n",
+    "    chunks=chunks,\n",
+    "    resampling=\"bilinear\",\n",
     ")\n",
     "\n",
-    "s2 = xr.open_dataset(\n",
-    "    s2_path,\n",
-    "    engine=\"rasterio\",\n",
-    ")\n",
-    "s2.coords[\"band\"] = [0, 1, 2]\n",
-    "s2"
+    "s2_dc\n",
+    "\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "319d2e55",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "3873be71",
    "metadata": {},
    "outputs": [],
    "source": [
-    "s2.hvplot.rgb(\n",
-    "    x=\"x\",\n",
-    "    y=\"y\",\n",
-    "    bands=\"band\",\n",
-    "    rasterize=True,\n",
-    "    xlabel=\"x\",\n",
-    "    ylabel=\"y\",\n",
-    ").redim.nodata(z=0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "33",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "del s2\n",
-    "gc.collect()"
+    "s2_first_date = s2_dc.isel(time=0)\n",
+    "\n",
+    "rgb = np.dstack([s2_first_date['B02_10m'],s2_first_date['B03_10m'],s2_first_date['B04_10m']])\n",
+    "scaled_rgb = np.clip(rgb/10000,0,1)\n",
+    "plt.imshow(scaled_rgb)\n"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mrs-env",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "mrs-env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -521,7 +322,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,

--- a/team_work/teamwork_data_guide.ipynb
+++ b/team_work/teamwork_data_guide.ipynb
@@ -43,7 +43,11 @@
     "from matplotlib import pyplot as plt\n",
     "\n",
     "import pystac_client\n",
-    "from odc import stac as odc_stac"
+    "from odc import stac as odc_stac\n",
+    "\n",
+    "import rioxarray as rxr\n",
+    "import hvplot.xarray\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -123,7 +127,9 @@
     "We use the **`odc-stac`** package to load STAC-compliant items directly into an **xarray** dataset.  \n",
     "For more details, refer to the [official documentation](https://odc-stac.readthedocs.io/en/latest/).\n",
     "\n",
-    "Specifically, we'll load the **Sentinel-1 SIG0** data we retrieved earlier as a three-dimensional datacube with dimensions **(time, lat, lon)**, and extract the **VV** polarization band."
+    "Specifically, we'll load the **Sentinel-1 SIG0** data we retrieved earlier as a three-dimensional datacube with dimensions **(time, lat, lon)**, and extract the **VV** polarization band.\n",
+    "\n",
+    "The chunks argument tells **`odc-stac`** to load the data in small, manageable blocks rather than all at once. This chunking keeps memory usage low by ensuring that only the portions of the datacube needed for a given operation are loaded into memory."
    ]
   },
   {
@@ -134,7 +140,7 @@
    "outputs": [],
    "source": [
     "bands = \"VV\"\n",
-    "chunks = {\"time\": 1, \"latitude\": 500, \"longitude\": 500}\n",
+    "chunks = {\"time\": 31, \"latitude\": 500, \"longitude\": 500}\n",
     "\n",
     "sig0_dc = odc_stac.load(\n",
     "    s1_items,\n",
@@ -370,6 +376,43 @@
     "rgb_da.plot.imshow(rgb=\"band\")\n",
     "plt.title(f\"Sentinel-2 L2A RGB, {first_date}\")\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed7b7fbc",
+   "metadata": {},
+   "source": [
+    "## Local data handling with rioxarray\n",
+    "\n",
+    "You can also work with local data in this project, either on JupyterHub or your own local machine. The rioxarray library extends xarray with geospatial raster support by integrating features from rasterio, a widely used library for reading and manipulating GeoTIFFs.\n",
+    "\n",
+    "Here's a simple example showing how to load and visualize a local GeoTIFF using rioxarray. In this snippet we will look at the tmensig0 parameter, which consists of the average SIG0 backscatter per relative orbit.\n",
+    "\n",
+    "In the last three lines, we load the GeoTIFF into an xarray DataArray, select the first and only band (da[0]), and scale the values by 0.1 to convert them from stored integer format to the actual backscatter values. Finally, we visualize the raster using hvplot.image, setting a reasonable range for the colorbar (clim=(-25, 5)), enabling robust normalization to ignore extreme outliers, fixing the aspect ratio, and rendering the image in grayscale for easier interpretation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6feb3773",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = (\n",
+    "    Path(r\"~/shared/datasets/fe/data\").expanduser() \n",
+    "    / \"sentinel1\" \n",
+    "    / \"parameters\" \n",
+    "    / \"EU010M\"\n",
+    "    / \"E051N015T1\"\n",
+    "    / \"tmensig0\"\n",
+    "    / \"M20160101_20171231_TMENSIG0-_S1-IWGRDH1VV-_124_B0104_EU010M_E051N015T1.tif\"\n",
+    ")\n",
+    "path = \"tmensig0/M20160101_20171231_TMENSIG0-_S1-IWGRDH1VV-_124_B0104_EU010M_E051N015T1.tif\"\n",
+    "\n",
+    "da = rxr.open_rasterio(path)\n",
+    "da = da[0] * 0.1\n",
+    "da.hvplot.image(clim=(-25, 5), robust=True, data_aspect=1, cmap=\"Greys_r\", rasterize=True)\n"
    ]
   }
  ],

--- a/team_work/teamwork_data_guide.ipynb
+++ b/team_work/teamwork_data_guide.ipynb
@@ -7,14 +7,6 @@
    "source": [
     "# Team work: Handling of available data\n",
     "\n",
-    "For testing your hypothesis in the team work part of the course, different datasets are provided:\n",
-    "\n",
-    "- [EODC STAC Catalog](https://services.eodc.eu/browser/#/v1/): Sentinel-1 and other datasets\n",
-    "- Data on JupyterHub:\n",
-    "    - Data used within the hands-on exercise (`~/shared/datasets/rs`): ALOS, ASCAT, soil moisture, ...\n",
-    "    - Austrian Datacube (`~/shared/datasets/fe/data`): Sentinel-1, Sentinel-2, Corine Land Cover, ...\n",
-    "- Additionally, you can bring in your own datasets or access other STAC catalogs.\n",
-    "\n",
     "In this notebook, examples are given how to access the different data sources through the JupyterHub. All shown methods aim to load a `xarray` object, which allows to use many predefined functions and offers a detailed [documentdation](https://docs.xarray.dev/). Besides that you can also work in QGIS, run local Python environments on you own PC or pick tools you are used to. Please be aware that your work needs to end up in a report and presentation at the end!"
    ]
   },

--- a/team_work/teamwork_data_guide.ipynb
+++ b/team_work/teamwork_data_guide.ipynb
@@ -385,11 +385,11 @@
    "source": [
     "## Local data handling with rioxarray\n",
     "\n",
-    "You can also work with local data in this project, either on JupyterHub or your own local machine. The rioxarray library extends xarray with geospatial raster support by integrating features from rasterio, a widely used library for reading and manipulating GeoTIFFs.\n",
+    "You can also work with local data in this project, either on JupyterHub or your own local machine. The `rioxarray` library extends `xarray` with geospatial raster support by integrating features from `rasterio`, a widely used library for reading and manipulating GeoTIFFs.\n",
     "\n",
-    "Here's a simple example showing how to load and visualize a local GeoTIFF using rioxarray. In this snippet we will look at the tmensig0 parameter, which consists of the average SIG0 backscatter per relative orbit.\n",
+    "Here's a simple example showing how to load and visualize a local GeoTIFF using `rioxarray`. In this snippet we will look at the `tmensig0` parameter, which consists of the average SIG0 backscatter per relative orbit.\n",
     "\n",
-    "In the last three lines, we load the GeoTIFF into an xarray DataArray, select the first and only band (da[0]), and scale the values by 0.1 to convert them from stored integer format to the actual backscatter values. Finally, we visualize the raster using hvplot.image, setting a reasonable range for the colorbar (clim=(-25, 5)), enabling robust normalization to ignore extreme outliers, fixing the aspect ratio, and rendering the image in grayscale for easier interpretation."
+    "In the last three lines, we load the GeoTIFF into an `xarray` DataArray, select the first and only band (`da[0]`), and scale the values by `0.1` to convert them from stored integer format to the actual backscatter values. Finally, we visualize the raster using `hvplot.image`, setting a reasonable range for the colorbar (`clim=(-25, 5)`), enabling robust normalization to ignore extreme outliers, fixing the aspect ratio, and rendering the image in grayscale for easier interpretation."
    ]
   },
   {
@@ -408,7 +408,6 @@
     "    / \"tmensig0\"\n",
     "    / \"M20160101_20171231_TMENSIG0-_S1-IWGRDH1VV-_124_B0104_EU010M_E051N015T1.tif\"\n",
     ")\n",
-    "path = \"tmensig0/M20160101_20171231_TMENSIG0-_S1-IWGRDH1VV-_124_B0104_EU010M_E051N015T1.tif\"\n",
     "\n",
     "da = rxr.open_rasterio(path)\n",
     "da = da[0] * 0.1\n",

--- a/team_work/teamwork_data_guide.ipynb
+++ b/team_work/teamwork_data_guide.ipynb
@@ -29,17 +29,14 @@
    "source": [
     "import gc\n",
     "import os\n",
+    "from pathlib import Path\n",
     "\n",
-    "import xarray as xr\n",
     "import numpy as np\n",
-    "from matplotlib import pyplot as plt\n",
-    "\n",
     "import pystac_client\n",
-    "from odc import stac as odc_stac\n",
-    "\n",
     "import rioxarray as rxr\n",
-    "import hvplot.xarray\n",
-    "from pathlib import Path"
+    "import xarray as xr\n",
+    "from matplotlib import pyplot as plt\n",
+    "from odc import stac as odc_stac"
    ]
   },
   {
@@ -88,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4dedcef",
+   "id": "7",
    "metadata": {},
    "source": [
     "Next, we query the **EODC STAC catalog** for items from the **SENTINEL1_SIG0_20M** collection that match these spatiotemporal constraints."
@@ -97,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbeb51ba",
+   "id": "9",
    "metadata": {},
    "source": [
     "We use the **`odc-stac`** package to load STAC-compliant items directly into an **xarray** dataset.  \n",
@@ -127,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +145,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9769746f",
+   "id": "11",
    "metadata": {},
    "source": [
     "To reduce storage requirements, this data is stored as **int16 arrays** together with a **scaling factor** that converts the integer values to floating-point reflectance values on demand.  \n",
@@ -160,11 +157,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "020ff60a",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "scale = s1_items[0].assets[\"VV\"].extra_fields.get(\"raster:bands\")[0][\"scale\"]\n",
     "nodata = s1_items[0].assets[\"VV\"].extra_fields.get(\"raster:bands\")[0][\"nodata\"]\n",
     "sig0_dc = sig0_dc.where(sig0_dc != nodata) / scale\n",
@@ -174,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c563ddc9",
+   "id": "13",
    "metadata": {},
    "source": [
     "We then compute the mean over the timeslices that remained, and plot it with xarray's plotting function, which provides us with some quality-of-life features like automatically adding axis labels and a legend for the colormap."
@@ -183,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7dd346f7",
+   "id": "15",
    "metadata": {},
    "source": [
     "Finally, we deallocate the memory for the data we just loaded and manually run python's garbage collector."
@@ -202,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b728cde",
+   "id": "17",
    "metadata": {},
    "source": [
     "## STAC data access: Sentinel-2 from CDSE\n",
@@ -231,22 +227,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b351b4b1",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(\"keys.txt\", \"r\") as f:\n",
-    "    access_key, secret_access_key = [line.strip() for line in f.readlines()]\n",
+    "with open(\"keys.txt\") as f:\n",
+    "    access_key, secret_access_key = [line.strip() for line in f]\n",
     "\n",
     "os.environ[\"AWS_ACCESS_KEY_ID\"] = access_key\n",
     "os.environ[\"AWS_SECRET_ACCESS_KEY\"] = secret_access_key\n",
     "os.environ[\"AWS_S3_ENDPOINT\"] = \"eodata.dataspace.copernicus.eu\"\n",
-    "os.environ[\"AWS_VIRTUAL_HOSTING\"] = \"FALSE\"\n"
+    "os.environ[\"AWS_VIRTUAL_HOSTING\"] = \"FALSE\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b58571de",
+   "id": "19",
    "metadata": {},
    "source": [
     "Now we simply follow a similar procedure to the one we employed for the EODC STAC, listing all the collections available in the CDSE catalog."
@@ -255,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93c068cb",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "070eadfd",
+   "id": "21",
    "metadata": {},
    "source": [
     "Again, just like in the Sentinel-1 Section, we define a spatiotemporal filter around the Innsbruck region and covering March 2022. We then query the CDSE catalog for Sentinel-2 Level 2A optical data that fulfills our requirements."
@@ -280,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c856f394",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +295,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed9ab2be",
+   "id": "23",
    "metadata": {},
    "source": [
     "This time, we query an xarray dataset with the bands [\"B02_10m\",\"B03_10m\",\"B04_10m\"], which correspond to blue, green and red, respectively. "
@@ -308,14 +304,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1cee1ba3",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
     "chunks = {\"time\": 1, \"latitude\": 500, \"longitude\": 500}\n",
     "\n",
     "\n",
-    "bands=[\"B02_10m\",\"B03_10m\",\"B04_10m\"]\n",
+    "bands = [\"B02_10m\", \"B03_10m\", \"B04_10m\"]\n",
     "\n",
     "s2_dc = odc_stac.load(\n",
     "    s2_items,\n",
@@ -332,7 +328,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "319d2e55",
+   "id": "25",
    "metadata": {},
    "source": [
     "Next, we'll visualize the first observation from our search results as a **true-color RGB image**.\n",
@@ -348,18 +344,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3873be71",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
-    "first_date = str(np.datetime_as_string(s2_dc.time[0], unit='D'))\n",
+    "first_date = str(np.datetime_as_string(s2_dc.time[0], unit=\"D\"))\n",
     "s2_data_first_date = s2_dc.isel(time=0)\n",
     "\n",
     "rgb_da = xr.concat(\n",
-    "    [s2_data_first_date[\"B04_10m\"],  # red\n",
-    "     s2_data_first_date[\"B03_10m\"],  # green\n",
-    "     s2_data_first_date[\"B02_10m\"]], # blue\n",
-    "    dim=\"band\"\n",
+    "    [\n",
+    "        s2_data_first_date[\"B04_10m\"],  # red\n",
+    "        s2_data_first_date[\"B03_10m\"],  # green\n",
+    "        s2_data_first_date[\"B02_10m\"],\n",
+    "    ],  # blue\n",
+    "    dim=\"band\",\n",
     ").assign_coords(band=[\"R\", \"G\", \"B\"])\n",
     "\n",
     "rgb_da = rgb_da.astype(\"float32\") / 10000.0\n",
@@ -372,7 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed7b7fbc",
+   "id": "27",
    "metadata": {},
    "source": [
     "## Local data handling with rioxarray\n",
@@ -387,14 +385,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6feb3773",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
     "path = (\n",
-    "    Path(r\"~/shared/datasets/fe/data\").expanduser() \n",
-    "    / \"sentinel1\" \n",
-    "    / \"parameters\" \n",
+    "    Path(r\"~/shared/datasets/fe/data\").expanduser()\n",
+    "    / \"sentinel1\"\n",
+    "    / \"parameters\"\n",
     "    / \"EU010M\"\n",
     "    / \"E051N015T1\"\n",
     "    / \"tmensig0\"\n",
@@ -403,15 +401,17 @@
     "\n",
     "da = rxr.open_rasterio(path)\n",
     "da = da[0] * 0.1\n",
-    "da.hvplot.image(clim=(-25, 5), robust=True, data_aspect=1, cmap=\"Greys_r\", rasterize=True)\n"
+    "da.hvplot.image(\n",
+    "    clim=(-25, 5), robust=True, data_aspect=1, cmap=\"Greys_r\", rasterize=True\n",
+    ")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "microwave-remote-sensing",
    "language": "python",
-   "name": "python3"
+   "name": "microwave-remote-sensing"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Improvements/additions on the introductory teamwork notebook. 


Changelog:
- Dropped both sections on local data
- Improved text on S1 EODC STAC section
- Added a section about loading and displaying S2 data from CDSE, along with some pointers on how to set up the required API keys.